### PR TITLE
Move recipe from Coiney cookbook.

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -88,7 +88,12 @@ default['nagios']['server']['checksum'] = '469381b2954392689c85d3db733e8da4bd43b
 default['nagios']['server']['src_dir'] = 'nagios'
 
 # for server from packages installation
-default['nagios']['server']['packages'] = %w[nagios3 nagios-nrpe-plugin nagios-images]
+case node['platform_family']
+when 'rhel', 'fedora'
+  default['nagios']['server']['packages'] = ['nagios', 'nagios-common', 'nagios-plugins-all']
+else
+  default['nagios']['server']['packages'] = %w[nagios3 nagios-nrpe-plugin nagios-images]
+end
 
 default['nagios']['notifications_enabled']     = 0
 default['nagios']['check_external_commands']   = true

--- a/templates/default/pagerduty.cfg.erb
+++ b/templates/default/pagerduty.cfg.erb
@@ -16,10 +16,10 @@ define contact {
 
 define command {
        command_name     notify-service-by-pagerduty
-       command_line     <%= node['nagios']['plugin_dir'] %>/notify_pagerduty.pl enqueue -f pd_nagios_object=service
+       command_line /usr/local/rvm/bin/rvm-exec <%= @rvm_bindir -%>notify_pagerduty -K $CONTACTPAGER$ -H $HOSTNAME$ -I $HOSTADDRESS$ -a $HOSTALIAS$ -S $SERVICEDESC$ -s $SERVICESTATE$ -N $NOTIFICATIONTYPE$ "$SERVICEOUTPUT$"
 }
 
 define command {
        command_name     notify-host-by-pagerduty
-       command_line     <%= node['nagios']['plugin_dir'] %>/notify_pagerduty.pl enqueue -f pd_nagios_object=host
+       command_line     /usr/local/rvm/bin/rvm-exec <%= @rvm_bindir -%>notify_pagerduty -K $CONTACTPAGER$ -H $HOSTNAME$ -I $HOSTADDRESS$ -a $HOSTALIAS$ -s $HOSTSTATE$ -N $NOTIFICATIONTYPE$ "$HOSTOUTPUT$"
 }


### PR DESCRIPTION
This recipe was first implemented as part of Coiney cookbook, but need to be moved here because of a race condition: if `pagerduty` contact was added by Nagios cookbook, nagios fails to start, since pagerduty config file is not created yet.

Replace Perl script for pagerDuty notifications with Ruby gem. During testing I could not make Perl script to work correctly, it seems that PagerDuty API changed and script does not support it. Alert submission did not return error, but had no effect. 
